### PR TITLE
Use serial.tools.list_ports to determine valid values

### DIFF
--- a/pySerialTransfer/pySerialTransfer.py
+++ b/pySerialTransfer/pySerialTransfer.py
@@ -1,47 +1,57 @@
+import os
 import sys
 import glob
 import serial
+import serial.tools.list_ports
 from platform import system
-from pySerialTransfer.CRC import CRC
+from .CRC import CRC
 
 
-CONTINUE        = 2
-NEW_DATA        = 1
-NO_DATA         = 0
-CRC_ERROR       = -1
-PAYLOAD_ERROR   = -2
+class InvalidSerialPort(Exception):
+    pass
+
+
+CONTINUE = 2
+NEW_DATA = 1
+NO_DATA = 0
+CRC_ERROR = -1
+PAYLOAD_ERROR = -2
 STOP_BYTE_ERROR = -3
 
-START_BYTE      = 0x7E
-STOP_BYTE       = 0x81
+START_BYTE = 0x7E
+STOP_BYTE = 0x81
 
 MAX_PACKET_SIZE = 0xFE
 
-find_start_byte    = 0
+find_start_byte = 0
 find_overhead_byte = 1
-find_payload_len   = 2
-find_payload       = 3
-find_crc           = 4
-find_end_byte      = 5
+find_payload_len = 2
+find_payload = 3
+find_crc = 4
+find_end_byte = 5
 
 
 def msb(val):
     return byte_val(val, num_bytes(val) - 1)
 
+
 def lsb(val):
     return byte_val(val, 0)
+
 
 def byte_val(val, pos):
     return int.from_bytes(((val >> (pos * 8)) & 0xFF).to_bytes(2, 'big'), 'big')
 
+
 def num_bytes(val):
-    num_bits  = val.bit_length()
+    num_bits = val.bit_length()
     num_bytes = num_bits // 8
-    
+
     if num_bits % 8:
         num_bytes += 1
-    
+
     return num_bytes
+
 
 def constrain(val, min_, max_):
     if val < min_:
@@ -49,6 +59,7 @@ def constrain(val, min_, max_):
     elif val > max_:
         return max_
     return val
+
 
 def open_ports():
     '''
@@ -58,28 +69,21 @@ def open_ports():
 
     :return port_list: list - all serial ports currently available
     '''
-    
-    if sys.platform.startswith('win'):
-        ports = ['COM%s' % (i + 1) for i in range(256)]
-    elif sys.platform.startswith('linux') or sys.platform.startswith('cygwin'):
-        # this excludes your current terminal "/dev/tty"
-        ports = glob.glob('/dev/tty[A-Za-z]*')
-    elif sys.platform.startswith('darwin'):
-        ports = glob.glob('/dev/tty.*')
-    else:
-        raise EnvironmentError('Unsupported platform')
-
     port_list = []
-    
-    for port in ports:
+
+    for port in serial_ports():
         try:
             s = serial.Serial(port)
             s.close()
             port_list.append(port)
         except (OSError, serial.SerialException):
             pass
-    
+
     return port_list
+
+
+def serial_ports():
+    return [p.device for p in serial.tools.list_ports.comports(include_links=True)]
 
 
 class SerialTransfer(object):
@@ -88,49 +92,48 @@ class SerialTransfer(object):
         Description:
         ------------
         Initialize transfer class and connect to the specified USB device
-        
+
         :param port: int or str - port the USB device is connected to
         :param baud: int        - baud (bits per sec) the device is configured for
-        
+
         :return: void
         '''
-        
+
         self.txBuff = [' ' for i in range(MAX_PACKET_SIZE - 1)]
         self.rxBuff = [' ' for i in range(MAX_PACKET_SIZE - 1)]
-        
-        self.bytesRead    = 0
-        self.status       = 0
+
+        self.bytesRead = 0
+        self.status = 0
         self.overheadByte = 0xFF
-        
+
         self.state = find_start_byte
-        port_str   = str(port)
-        
-        if system() == 'Windows':
-            if 'COM' not in port_str:
-                self.port_name = 'COM{}'.format(port_str)
-            else:
-                self.port_name = port_str
-        else:
-            if '/dev/' not in port:
-                self.port_name = '/dev/{}'.format(port_str)
-            else:
-                self.port_name = port_str
-        
-        self.crc                 = CRC()
-        self.connection          = serial.Serial()
-        self.connection.port     = self.port_name
+
+        self.port_name = None
+        for p in serial_ports():
+            if p == port or os.path.split(p)[-1] == port:
+                self.port_name = p
+                break
+
+        if self.port_name is None:
+            raise InvalidSerialPort('Invalid serial port specified.\
+                Valid options are {ports},  but {port} was provided'.format(
+                    **{'ports': serial_ports(), 'port': port}))
+
+        self.crc = CRC()
+        self.connection = serial.Serial()
+        self.connection.port = self.port_name
         self.connection.baudrate = baud
         self.open()
-    
+
     def open(self):
         '''
         Description:
         ------------
         Open USB port and connect to device if possible
-        
+
         :return: bool - True if successful, else False
         '''
-        
+
         if self.connection.closed:
             try:
                 self.connection.open()
@@ -139,19 +142,19 @@ class SerialTransfer(object):
                 print(e)
                 return False
         return True
-    
+
     def close(self):
         '''
         Description:
         ------------
         Close connection to the USB device
-        
+
         :return: void
         '''
-        
+
         if self.connection.is_open:
             self.connection.close()
-        
+
     def calc_overhead(self, pay_len):
         '''
         Description:
@@ -160,50 +163,50 @@ class SerialTransfer(object):
         byte and stores it in the class's overheadByte variable. This
         variable holds the byte position (within the payload) of the
         first payload byte equal to that of START_BYTE
-        
+
         :param pay_len: int - number of bytes in the payload
-        
+
         :return: void
         '''
-        
+
         self.overheadByte = 0xFF
 
         for i in range(pay_len):
             if self.txBuff[i] == START_BYTE:
                 self.overheadByte = i
                 break
-    
+
     def find_last(self, pay_len):
         '''
         Description:
         ------------
         Finds last instance of the value START_BYTE within the given
         packet array
-        
+
         :param pay_len: int - number of bytes in the payload
-        
-        :return: int - location of the last instance of the value START_BYTE 
+
+        :return: int - location of the last instance of the value START_BYTE
                        within the given packet array
         '''
-        
+
         if pay_len <= MAX_PACKET_SIZE:
             for i in range(pay_len - 1, 0, -1):
                 if self.txBuff[i] == START_BYTE:
                     return i
         return -1
-    
+
     def stuff_packet(self, pay_len):
         '''
         Description:
         ------------
         Enforces the COBS (Consistent Overhead Stuffing) ruleset across
         all bytes in the packet against the value of START_BYTE
-        
+
         :param pay_len: int - number of bytes in the payload
-        
+
         :return: void
         '''
-        
+
         refByte = self.find_last(pay_len)
 
         if (not refByte == -1) and (refByte <= MAX_PACKET_SIZE):
@@ -217,47 +220,47 @@ class SerialTransfer(object):
         Description:
         ------------
         Send a specified number of bytes in packetized form
-        
+
         :param message_len: int - number of bytes from the txBuff to send as
                                   payload in the packet
-        
+
         :return: bool - whether or not the operation was successful
         '''
-        
+
         stack = []
         message_len = constrain(message_len, 0, MAX_PACKET_SIZE)
-        
+
         try:
             self.calc_overhead(message_len)
             self.stuff_packet(message_len)
             found_checksum = self.crc.calculate(self.txBuff, message_len)
-            
+
             stack.append(START_BYTE)
             stack.append(self.overheadByte)
             stack.append(message_len)
-            
+
             for i in range(message_len):
                 if type(self.txBuff[i]) == str:
                     val = ord(self.txBuff[i])
                 else:
                     val = int(self.txBuff[i])
-                
+
                 stack.append(val)
-            
+
             stack.append(found_checksum)
             stack.append(STOP_BYTE)
-            
+
             stack = bytearray(stack)
-            
+
             if self.open():
                 self.connection.write(stack)
-            
+
             return True
-        
+
         except:
             import traceback
             traceback.print_exc()
-            
+
             return False
 
     def unpack_packet(self, pay_len):
@@ -265,21 +268,21 @@ class SerialTransfer(object):
         Description:
         ------------
         Unpacks all COBS-stuffed bytes within the array
-        
+
         :param pay_len: int - number of bytes in the payload
-        
+
         :return: void
         '''
 
         testIndex = self.recOverheadByte
-        delta     = 0
-    
+        delta = 0
+
         if testIndex <= MAX_PACKET_SIZE:
             while self.rxBuff[testIndex]:
                 delta = self.rxBuff[testIndex]
                 self.rxBuff[testIndex] = START_BYTE
                 testIndex += delta
-                
+
             self.rxBuff[testIndex] = START_BYTE
 
     def available(self):
@@ -288,25 +291,25 @@ class SerialTransfer(object):
         ------------
         Parses incoming serial data, analyzes packet contents,
         and reports errors/successful packet reception
-        
+
         :return self.bytesRead: int - number of bytes read from the received
                                       packet
         '''
-        
+
         if self.open():
             if self.connection.in_waiting:
                 while self.connection.in_waiting:
                     recChar = int.from_bytes(self.connection.read(),
                                              byteorder='big')
-    
+
                     if self.state == find_start_byte:##############################
                         if recChar == START_BYTE:
                             self.state = find_overhead_byte
-    
+
                     elif self.state == find_overhead_byte:
                         self.recOverheadByte = recChar
                         self.state           = find_payload_len
-    
+
                     elif self.state == find_payload_len:###########################
                         if recChar <= MAX_PACKET_SIZE:
                             self.bytesToRec = recChar
@@ -317,18 +320,18 @@ class SerialTransfer(object):
                             self.state     = find_start_byte
                             self.status    = PAYLOAD_ERROR
                             return self.bytesRead
-    
+
                     elif self.state == find_payload:###############################
                         if self.payIndex < self.bytesToRec:
                             self.rxBuff[self.payIndex] = recChar
                             self.payIndex += 1
-    
+
                             if self.payIndex == self.bytesToRec:
                                 self.state = find_crc
-    
+
                     elif self.state == find_crc:###################################
                         found_checksum = self.crc.calculate(self.rxBuff, self.bytesToRec)
-    
+
                         if found_checksum == recChar:
                             self.state = find_end_byte
                         else:
@@ -336,23 +339,23 @@ class SerialTransfer(object):
                             self.state     = find_start_byte
                             self.status    = CRC_ERROR
                             return self.bytesRead
-                    
+
                     elif self.state == find_end_byte:##############################
                         self.state = find_start_byte
-    
+
                         if recChar == STOP_BYTE:
                             self.unpack_packet(self.bytesToRec)
                             self.bytesRead = self.bytesToRec
                             self.status    = NEW_DATA
                             return self.bytesRead
-    
+
                         self.bytesRead = 0
                         self.status    = STOP_BYTE_ERROR
                         return self.bytesRead
-                        
+
                     else:##########################################################
                         print('ERROR: Undefined state: {}'.format(self.state))
-    
+
                         self.bytesRead = 0
                         self.state     = find_start_byte
                         return self.bytesRead
@@ -360,35 +363,34 @@ class SerialTransfer(object):
                 self.bytesRead = 0
                 self.status    = NO_DATA
                 return self.bytesRead
-    
+
         self.bytesRead = 0
-        self.status    = CONTINUE
+        self.status = CONTINUE
         return self.bytesRead
 
 
 if __name__ == '__main__':
     try:
-        link = SerialTransfer(13)
-    
+        link = SerialTransfer('ttyUSB0')
+
         link.txBuff[0] = 'h'
         link.txBuff[1] = 'i'
         link.txBuff[2] = '\n'
-        
+
         link.send(3)
-        
+
         while not link.available():
             if link.status < 0:
                 print('ERROR: {}'.format(link.status))
-            
+
         print('Response received:')
-        
+
         response = ''
         for index in range(link.bytesRead):
             response += chr(link.rxBuff[index])
-        
+
         print(response)
         link.close()
-        
+
     except KeyboardInterrupt:
         link.close()
-    


### PR DESCRIPTION
Resolves #2

Use pySerial tools to determine the list of available serial ports on the system ([docs](https://pyserial.readthedocs.io/en/latest/tools.html)).

Test `port` parameter against full device path and last path fragment, using the os path seperator to split the provided value.

This works for me - it means I can specify my port using shorthand ('serial0', 'ttyUSB0') or whatever, or by full path ('/dev/ttyUSB0'), but those values are tested against those available to pyserial to ensure that they're at least vaguely sane.

I hope this is ok. let me know if it works for you, or if there's any tweaks or changes you'd like to see.