### PR TITLE
Less connection opening/closing

### DIFF
--- a/pySerialTransfer/pySerialTransfer.py
+++ b/pySerialTransfer/pySerialTransfer.py
@@ -123,18 +123,17 @@ class SerialTransfer(object):
         self.connection = serial.Serial()
         self.connection.port = self.port_name
         self.connection.baudrate = baud
-        self.open()
 
     def open(self):
         '''
         Description:
         ------------
-        Open USB port and connect to device if possible
+        Open serial port and connect to device if possible
 
         :return: bool - True if successful, else False
         '''
 
-        if self.connection.closed:
+        if not self.connection.is_open():
             try:
                 self.connection.open()
                 return True
@@ -147,7 +146,7 @@ class SerialTransfer(object):
         '''
         Description:
         ------------
-        Close connection to the USB device
+        Close serial port
 
         :return: void
         '''
@@ -308,20 +307,20 @@ class SerialTransfer(object):
 
                     elif self.state == find_overhead_byte:
                         self.recOverheadByte = recChar
-                        self.state           = find_payload_len
+                        self.state = find_payload_len
 
                     elif self.state == find_payload_len:###########################
                         if recChar <= MAX_PACKET_SIZE:
                             self.bytesToRec = recChar
-                            self.payIndex   = 0
-                            self.state      = find_payload
+                            self.payIndex = 0
+                            self.state = find_payload
                         else:
                             self.bytesRead = 0
-                            self.state     = find_start_byte
-                            self.status    = PAYLOAD_ERROR
+                            self.state = find_start_byte
+                            self.status = PAYLOAD_ERROR
                             return self.bytesRead
 
-                    elif self.state == find_payload:###############################
+                    elif self.state == find_payload:
                         if self.payIndex < self.bytesToRec:
                             self.rxBuff[self.payIndex] = recChar
                             self.payIndex += 1
@@ -336,8 +335,8 @@ class SerialTransfer(object):
                             self.state = find_end_byte
                         else:
                             self.bytesRead = 0
-                            self.state     = find_start_byte
-                            self.status    = CRC_ERROR
+                            self.state = find_start_byte
+                            self.status = CRC_ERROR
                             return self.bytesRead
 
                     elif self.state == find_end_byte:##############################
@@ -346,22 +345,22 @@ class SerialTransfer(object):
                         if recChar == STOP_BYTE:
                             self.unpack_packet(self.bytesToRec)
                             self.bytesRead = self.bytesToRec
-                            self.status    = NEW_DATA
+                            self.status = NEW_DATA
                             return self.bytesRead
 
                         self.bytesRead = 0
-                        self.status    = STOP_BYTE_ERROR
+                        self.status = STOP_BYTE_ERROR
                         return self.bytesRead
 
                     else:##########################################################
                         print('ERROR: Undefined state: {}'.format(self.state))
 
                         self.bytesRead = 0
-                        self.state     = find_start_byte
+                        self.state = find_start_byte
                         return self.bytesRead
             else:
                 self.bytesRead = 0
-                self.status    = NO_DATA
+                self.status = NO_DATA
                 return self.bytesRead
 
         self.bytesRead = 0


### PR DESCRIPTION
When instantiating an instance of Serial with a port specified,
that port will be automatically opened, without a need to explicitly do
so.

Additionally, use of `closed` to determine a port's status seems flawed, as it can erroneously
return `False`, leading to attempts to write to a closed port.
Switching to `is_open` appears to be less error prone.