### PR TITLE
Fix absence of format_str when receiving str and dict objects

### DIFF
--- a/pySerialTransfer/pySerialTransfer.py
+++ b/pySerialTransfer/pySerialTransfer.py
@@ -313,6 +313,7 @@ class SerialTransfer(object):
         
         if (obj_type == str) or (obj_type == dict):
             buff = bytes(self.rxBuff[start_pos:(start_pos + obj_byte_size)])
+            format_str = '%ds' % len(buff)
             
         elif obj_type == float:
             format_str = 'f'


### PR DESCRIPTION
Found a bug when parsing serial response as a string in 2.1.0 version. 
The following error is thrown:
UnboundLocalError: local variable 'format_str' referenced before assignment

It turned out that there is no 'format_str' definition in one of the if statements.