### PR TITLE
Fix Latency Issue

### DIFF
--- a/pySerialTransfer/pySerialTransfer.py
+++ b/pySerialTransfer/pySerialTransfer.py
@@ -533,12 +533,8 @@ class SerialTransfer(object):
                             return self.bytesRead
 
                     elif self.state == find_payload:
-                        if self.payIndex < self.bytesToRec:
-                            self.rxBuff[self.payIndex] = recChar
-                            self.payIndex += 1
-
-                            if self.payIndex == self.bytesToRec:
-                                self.state = find_crc
+                        self.rxBuff[0:self.bytesToRec] = [recChar] + list(self.connection.read(self.bytesToRec - 1))
+                        self.state = find_crc
 
                     elif self.state == find_crc:
                         found_checksum = self.crc.calculate(

--- a/pySerialTransfer/pySerialTransfer.py
+++ b/pySerialTransfer/pySerialTransfer.py
@@ -504,11 +504,9 @@ class SerialTransfer(object):
         '''
 
         if self.open():
-            bytes = self.connection.read(self.connection.in_waiting)
-            
-            if bytes:
-                for byte in bytes:
-                    recChar = int.from_bytes(byte,
+            if self.connection.in_waiting:
+                while self.connection.in_waiting:
+                    recChar = int.from_bytes(self.connection.read(),
                                              byteorder='big')
 
                     if self.state == find_start_byte:
@@ -602,7 +600,7 @@ class SerialTransfer(object):
             
             return True
         
-        elif self.debug and self.status <=0:
+        elif self.debug and not self.status:
             if self.status == CRC_ERROR:
                 err_str = 'CRC_ERROR'
             elif self.status == PAYLOAD_ERROR:


### PR DESCRIPTION
Fix latency issue mentioned in #36 by removing repeated calls to self.connection.read(). On Windows (and maybe other OSes), the PySerial read() function can take approx 1ms, even when only fetching 1 byte. If the payload is 254 bytes, that adds about 1/4 second of latency to each message. This fix removes the multiple calls to read() by fetching the number of bytes listed in the message header all at once.

This also reverts a previous commit on the master branch that fixed the issue, but introduced new issues. That previous commit would throw away any new messages in the buffer and only return the oldest message.