### PR TITLE
Fix detection of zero payload length packets

### DIFF
--- a/pySerialTransfer/pySerialTransfer.py
+++ b/pySerialTransfer/pySerialTransfer.py
@@ -540,7 +540,7 @@ class SerialTransfer(object):
                         self.state = find_payload_len
 
                     elif self.state == find_payload_len:
-                        if recChar <= MAX_PACKET_SIZE:
+                        if recChar > 0 and recChar <= MAX_PACKET_SIZE:
                             self.bytesToRec = recChar
                             self.payIndex = 0
                             self.state = find_payload


### PR DESCRIPTION
I encountered some strange behaviour during the usage of this library, especially when sending good amounts of data quite often. The status would sometimes return me CRC_ERROR, etc. but after a while the program would simply hang.

I traced this back to the state machine which does not discard packets whose packet length is 0.
This way the fsm would always hang in `find_payload` because the subsequent `if self.payIndex < self.bytesToRec` would never trigger as `self.bytesToRec` was zero.

While the library cannot send packets with zero payload length I believe, this fault can still occur during transmissions.
Since the fsm locks itself out from proceeding to the next states, the library keeps spinning in the same state forever.

My change adds the check to acknowledge a packet as valid if it's payload length is bigger than zero but smaller or equal the maximum packet size, otherwise discard it.
I checked the Arduino implementation of this library and the 'greater than zero' check is present there, but not here.