### PR TITLE
receive string remove trailing 0s

### DIFF
--- a/pySerialTransfer/pySerialTransfer.py
+++ b/pySerialTransfer/pySerialTransfer.py
@@ -372,6 +372,10 @@ class SerialTransfer(object):
             unpacked_response = struct.unpack(self.byte_format + format_str, buff)[0]
         
         if (obj_type == str) or (obj_type == dict):
+            # remove any trailing bytes of value 0 from data
+            if 0 in unpacked_response:
+                unpacked_response = unpacked_response[:unpacked_response.index(0)]
+
             unpacked_response = unpacked_response.decode('utf-8')
         
         if obj_type == dict:


### PR DESCRIPTION
When sending strings via SerialTransfer from an Arduino in C++, it is often most practical to work with strings of fixed length, even if the desired content to encode is variable.

When the unused characters in the C++ string have a default value of 0 when encoded as bytes, pySerialTransfer raises an error when it tries to decode the bytes into a string. By removing the unused bytes from the data, pySerialTransfer can succeed in parsing the string.