### PR TITLE
Rename crc instance variable to avoid shadowing

### DIFF
--- a/pySerialTransfer/CRC.py
+++ b/pySerialTransfer/CRC.py
@@ -55,7 +55,7 @@ class CRC(object):
 
 
 if __name__ == '__main__':
-    crc = CRC()
-    print(crc.print_table())
+    crc_instance = CRC()
+    print(crc_instance.print_table())
     print(' ')
-    print(hex(crc.calculate(0x31)).upper().replace('X', 'x'))
+    print(hex(crc_instance.calculate(0x31)).upper().replace('X', 'x'))


### PR DESCRIPTION
Rename `CRC()` instance variable to avoid the having the `crc` variable in `calculate` shadowing it.

addresses #81 