### PR TITLE
Remove unused variables

### DIFF
--- a/pySerialTransfer/CRC.py
+++ b/pySerialTransfer/CRC.py
@@ -6,7 +6,7 @@ class CRC(object):
         self.poly      = polynomial & 0xFF
         self.crc_len   = crc_len
         self.table_len = pow(2, crc_len)
-        self.cs_table  = [' ' for x in range(self.table_len)]
+        self.cs_table  = [' '] * self.table_len
         
         self.generate_table()
     

--- a/pySerialTransfer/pySerialTransfer.py
+++ b/pySerialTransfer/pySerialTransfer.py
@@ -154,8 +154,8 @@ class SerialTransfer(object):
         self.bytes_to_rec = 0
         self.pay_index = 0
         self.rec_overhead_byte = 0
-        self.tx_buff = [' ' for i in range(MAX_PACKET_SIZE)]
-        self.rx_buff = [' ' for i in range(MAX_PACKET_SIZE)]
+        self.tx_buff = [' '] * MAX_PACKET_SIZE
+        self.rx_buff = [' '] * MAX_PACKET_SIZE
 
         self.debug        = debug
         self.id_byte       = 0

--- a/pySerialTransfer/pySerialTransfer.py
+++ b/pySerialTransfer/pySerialTransfer.py
@@ -508,7 +508,6 @@ class SerialTransfer(object):
         '''
 
         test_index = self.rec_overhead_byte
-        delta = 0
 
         if test_index <= MAX_PACKET_SIZE:
             while self.rx_buff[test_index]:

--- a/pySerialTransfer/pySerialTransfer.py
+++ b/pySerialTransfer/pySerialTransfer.py
@@ -498,13 +498,11 @@ class SerialTransfer(object):
 
             return False
 
-    def unpack_packet(self, pay_len):
+    def unpack_packet(self):
         '''
         Description:
         ------------
         Unpacks all COBS-stuffed bytes within the array
-
-        :param pay_len: int - number of bytes in the payload
 
         :return: void
         '''
@@ -593,7 +591,7 @@ class SerialTransfer(object):
                         self.state = find_start_byte
 
                         if rec_char == STOP_BYTE:
-                            self.unpack_packet(self.bytes_to_rec)
+                            self.unpack_packet()
                             self.bytes_read = self.bytes_to_rec
                             self.status = NEW_DATA
                             return self.bytes_read


### PR DESCRIPTION
Fix up instances where variables are assigned unecessarily, either a method params, local variables, or iterator variables in list comprehensions.
