### PR TITLE
Fix encoding when using `tx_obj` with a value of type `bool`

### DIFF
--- a/pySerialTransfer/pySerialTransfer.py
+++ b/pySerialTransfer/pySerialTransfer.py
@@ -267,11 +267,11 @@ class SerialTransfer(object):
             elif isinstance(val, float):
                 format_str = 'f'
                 
-            elif isinstance(val, int):
-                format_str = 'i'
-                
             elif isinstance(val, bool):
                 format_str = '?'
+                
+            elif isinstance(val, int):
+                format_str = 'i'
                 
             elif isinstance(val, list):
                 for el in val:


### PR DESCRIPTION
Fix an issue where attempting to call tx_obj(True) resulted in incorrect values being inserted in tx_buff.

Addresses #91