### PR TITLE
Fix debug print statements in `tick()`

### DIFF
--- a/pySerialTransfer/pySerialTransfer.py
+++ b/pySerialTransfer/pySerialTransfer.py
@@ -634,7 +634,7 @@ class SerialTransfer(object):
             
             return True
         
-        elif self.debug and not self.status:
+        elif self.debug and self.status in [CRC_ERROR, PAYLOAD_ERROR, STOP_BYTE_ERROR]:
             if self.status == CRC_ERROR:
                 err_str = 'CRC_ERROR'
             elif self.status == PAYLOAD_ERROR:


### PR DESCRIPTION
Fix an issue where debug message for `PAYLOAD_ERROR` and `STOP_BYTE_ERROR` statuses are not printed in the `tick()` method.

This is because these statuse values fail to meet the condition `self.debug and not self.status` because they are negative values, unlike `CRC_ERROR` which is 0.

e.g.
```
bool(True and 0)
False
bool(True and -1)
True
```