### PR TITLE
Add missing param to docstring

### DIFF
--- a/pySerialTransfer/pySerialTransfer.py
+++ b/pySerialTransfer/pySerialTransfer.py
@@ -457,6 +457,7 @@ class SerialTransfer(object):
 
         :param message_len: int - number of bytes from the tx_buff to send as
                                   payload in the packet
+        :param packet_id:   int - ID of the packet to send                                  
 
         :return: bool - whether or not the operation was successful
         '''


### PR DESCRIPTION
Add  param `packet_id` to `send` method  docstring.