### PR TITLE
Use Python 3 style classes

### DIFF
--- a/examples/data/Python/rx_data.py
+++ b/examples/data/Python/rx_data.py
@@ -2,7 +2,7 @@ from time import sleep
 from pySerialTransfer import pySerialTransfer as txfer
 
 
-class struct:
+class Struct:
     z = ''
     y = 0.0
 
@@ -12,7 +12,7 @@ arr = ''
 
 if __name__ == '__main__':
     try:
-        testStruct = struct
+        testStruct = Struct
         link = txfer.SerialTransfer('COM11')
         
         link.open()

--- a/examples/data/Python/rx_data.py
+++ b/examples/data/Python/rx_data.py
@@ -2,7 +2,7 @@ from time import sleep
 from pySerialTransfer import pySerialTransfer as txfer
 
 
-class struct(object):
+class struct:
     z = ''
     y = 0.0
 

--- a/examples/data/Python/tx_data.py
+++ b/examples/data/Python/tx_data.py
@@ -2,7 +2,7 @@ from time import sleep
 from pySerialTransfer import pySerialTransfer as txfer
 
 
-class struct(object):
+class struct:
     z = '$'
     y = 4.5
 

--- a/pySerialTransfer/CRC.py
+++ b/pySerialTransfer/CRC.py
@@ -1,7 +1,7 @@
 import sys
 
 
-class CRC(object):
+class CRC:
     def __init__(self, polynomial=0x9B, crc_len=8):
         self.poly      = polynomial & 0xFF
         self.crc_len   = crc_len

--- a/pySerialTransfer/pySerialTransfer.py
+++ b/pySerialTransfer/pySerialTransfer.py
@@ -130,7 +130,7 @@ def serial_ports():
     return [p.device for p in serial.tools.list_ports.comports(include_links=True)]
 
 
-class SerialTransfer(object):
+class SerialTransfer:
     def __init__(self, port, baud=115200, restrict_ports=True, debug=True, byte_format=BYTE_FORMATS['little-endian'], timeout=0.05, write_timeout=None):
         '''
         Description:


### PR DESCRIPTION
In Python 3, you don't need to explicitly inherit from object (i.e., class MyClass(object):) as was the case in Python 2. In Python 3, all classes are new-style classes, so class MyClass: and class MyClass(object): are equivalent.