### PR TITLE
Replace print statements with logging in Python library

### DIFF
--- a/pySerialTransfer/__init__.py
+++ b/pySerialTransfer/__init__.py
@@ -1,1 +1,5 @@
+import logging
+
 from . import *
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/pySerialTransfer/pySerialTransfer.py
+++ b/pySerialTransfer/pySerialTransfer.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import json
 import struct
@@ -162,7 +163,7 @@ class SerialTransfer:
                 self.connection.open()
                 return True
             except serial.SerialException as e:
-                print(e)
+                logging.exception(e)
                 return False
         return True
     
@@ -564,7 +565,7 @@ class SerialTransfer:
                         return self.bytes_read
 
                     else:
-                        print('ERROR: Undefined state: {}'.format(self.state))
+                        logging.error('Undefined state: {}'.format(self.state))
 
                         self.bytes_read = 0
                         self.state = State.FIND_START_BYTE
@@ -594,7 +595,7 @@ class SerialTransfer:
             if self.id_byte < len(self.callbacks):
                 self.callbacks[self.id_byte]()
             elif self.debug:
-                print('ERROR: No callback available for packet ID {}'.format(self.id_byte))
+                logging.error('No callback available for packet ID {}'.format(self.id_byte))
             
             return True
         
@@ -608,6 +609,6 @@ class SerialTransfer:
             else:
                 err_str = str(self.status)
                 
-            print('ERROR: {}'.format(err_str))
+            logging.error('{}'.format(err_str))
         
         return False

--- a/tests/test_py_serial_transfer.py
+++ b/tests/test_py_serial_transfer.py
@@ -419,33 +419,33 @@ def test_set_callbacks_with_non_iterable():
     assert st.callbacks == original_callbacks
     
     
-
-@patch('builtins.print')
 @pytest.mark.parametrize('incoming_byte_values, expected_print_str', [
     ([0x7E, 0, 0xFF, 0x04, 0x01, 0x02, 0x03, 0x04, 0xFF, 0x81], 'CRC_ERROR'),
     ([0x7E, 0, 0xFF, 0x04, 0x01, 0x02, 0x03, 0x04, 0xC8, 0x7E], 'STOP_BYTE_ERROR'),
     ([0x7E, 0, 0xFF, 0xFF, 0x01, 0x02, 0x03, 0x04, 0xC8, 0x81], 'PAYLOAD_ERROR'),
 ])
-def test_tick_with_invalid_data(mock_print, incoming_byte_values, expected_print_str):
+def test_tick_with_invalid_data(caplog, incoming_byte_values, expected_print_str):
     """Test that the tick method returns False when invalid data is received."""
     st = SerialTransfer('COM3')
     make_incoming_byte_stream(incoming_byte_values=incoming_byte_values, connection=st.connection)
     result = st.tick()
     assert result is False
-    mock_print.assert_called_once_with(f"ERROR: {expected_print_str}")
+    assert len(caplog.records) == 1
+    assert caplog.records[0].message == f"{expected_print_str}"
+    assert caplog.records[0].levelname == 'ERROR'
 
 
-@patch('builtins.print')
 @pytest.mark.parametrize('incoming_byte_values, expected_print_str', [
     ([0x7E, 0, 0xFF, 0x04, 0x01, 0x02, 0x03, 0x04, 0xFF, 0x81], 'CRC_ERROR'),
     ([0x7E, 0, 0xFF, 0x04, 0x01, 0x02, 0x03, 0x04, 0xC8, 0x7E], 'STOP_BYTE_ERROR'),
     ([0x7E, 0, 0xFF, 0xFF, 0x01, 0x02, 0x03, 0x04, 0xC8, 0x81], 'PAYLOAD_ERROR'),
 ])
-def test_tick_with_invalid_data_debug_false(mock_print, incoming_byte_values, expected_print_str):
+def test_tick_with_invalid_data_debug_false(caplog, incoming_byte_values, expected_print_str):
     """Test that the tick method does not print when presented with invalid data and debug is False."""
     st = SerialTransfer('COM3', debug=False)
     make_incoming_byte_stream(incoming_byte_values=incoming_byte_values, connection=st.connection)
     result = st.tick()
     assert result is False
-    mock_print.assert_not_called()
+    assert len(caplog.records) == 0
+
     


### PR DESCRIPTION
This PR replaces all instances of `print` statements in the library with Python's built-in `logging` module. The `print` function, while useful for simple debugging or output, has several disadvantages when used in a library:

1. **Lack of flexibility**: `print` always writes to standard output, and cannot be easily redirected to other destinations like a file or a network socket.
2. **No severity levels**: `print` does not distinguish between different kinds of messages, such as debug, info, warning, and error messages.
3. **No control for library users**: If a library uses `print`, the application using the library cannot easily control when these messages should be output.

On the other hand, the `logging` module provides a flexible framework for emitting log messages from Python programs. It is based on a modular and configurable architecture, using handlers, formatters, and filters to generate log messages of different severity levels to various output destinations.

By using `logging` instead of `print`, we can provide users of the library with the following benefits:

1. **Control over message level**: Users can choose to only display messages above a certain severity level.
2. **Control over message destination**: Users can choose to route messages to one or more destinations, including the console, a file, a network socket, or even an email server.
3. **Control over message format**: Users can choose the precise format of their log messages.

Users of the library can configure logging in their application as follows:

```python
import logging

# Create a custom logger
logger = logging.getLogger(__name__)

# Create handlers
c_handler = logging.StreamHandler()
f_handler = logging.FileHandler('file.log')
c_handler.setLevel(logging.WARNING)
f_handler.setLevel(logging.ERROR)

# Create formatters and add it to handlers
c_format = logging.Formatter('%(name)s - %(levelname)s - %(message)s')
f_format = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
c_handler.setFormatter(c_format)
f_handler.setFormatter(f_format)

# Add handlers to the logger
logger.addHandler(c_handler)
logger.addHandler(f_handler)
```

In this example, two handlers are created: `c_handler` which logs warning messages or higher to the console, and `f_handler` which logs error messages or higher to a file. They are added to the logger, which replaces the `NullHandler` added by the library. Now, when the library code calls `logging.getLogger(__name__)`, it will return the logger configured in the application, and log messages will be handled according to the application's configuration.